### PR TITLE
Remove deprecated DKMS CLEAN

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,4 @@
 MAKE="make TARGET=${kernelver} CFLAGS_MODULE+=@CFLGS@"
-CLEAN="make clean"
 PACKAGE_NAME="zenpower"
 PACKAGE_VERSION="@VERSION@"
 BUILT_MODULE_NAME[0]="zenpower"


### PR DESCRIPTION
CLEAN can be safely removed.