### PR TITLE
Adapt AMD header includes for Linux kernel >= 6.16

### DIFF
--- a/zenpower.c
+++ b/zenpower.c
@@ -32,17 +32,16 @@
  *  - Current formulas and CCD temp addresses were discovered experimentally
  */
 
+#include <linux/version.h>
+
 #include <linux/hwmon.h>
 #include <linux/module.h>
 #include <linux/pci.h>
-#include <asm/amd_nb.h>
-#include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) /* asm/amd_node.h */
-static u16 amd_pci_dev_to_node_id(struct pci_dev *pdev)
-{
-	return PCI_SLOT(pdev->devfn) - AMD_NODE0_PCI_SLOT;
-}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#include <asm/amd/nb.h>
+#else
+#include <asm/amd_nb.h>
 #endif
 
 MODULE_DESCRIPTION("AMD ZEN family CPU Sensors Driver");

--- a/zenpower.c
+++ b/zenpower.c
@@ -44,6 +44,13 @@
 #include <asm/amd_nb.h>
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) /* asm/amd_node.h */
+static u16 amd_pci_dev_to_node_id(struct pci_dev *pdev)
+{
+	return PCI_SLOT(pdev->devfn) - AMD_NODE0_PCI_SLOT;
+}
+#endif
+
 MODULE_DESCRIPTION("AMD ZEN family CPU Sensors Driver");
 MODULE_AUTHOR("Anthony Wang");
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
Switch include path to <asm/amd/nb.h> for Linux 6.16 and later,
while maintaining backward compatibility with <asm/amd_nb.h>.